### PR TITLE
Add indentation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/vim,git,node,macos,windows,composer,sublimetext,phpcodesniffer,visualstudiocode
+
+out

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nftables",
+	"name": "nftables",
 	"displayName": "nftables",
 	"publisher": "omBratteng",
 	"description": "Language support package for the nftables configuration syntax",
@@ -7,25 +7,62 @@
 		"type": "git",
 		"url": "https://github.com/omBratteng/vscode-nftables"
 	},
-    "version": "0.0.3",
-    "engines": {
-        "vscode": "^1.38.0"
-    },
-    "categories": [
-        "Programming Languages"
+	"version": "0.0.3",
+	"engines": {
+		"vscode": "^1.38.0"
+	},
+	"categories": [
+		"Programming Languages"
 	],
 	"icon": "icon.png",
-    "contributes": {
-        "languages": [{
-            "id": "nft",
-            "aliases": ["NFTables", "nft"],
-            "extensions": [".nft"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "nft",
-            "scopeName": "source.nft",
-            "path": "./syntaxes/nft.json"
-        }]
-    }
+	"activationEvents": [
+		"onLanguage:nft",
+		"onCommand:extension.nft"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"languages": [
+			{
+				"id": "nft",
+				"aliases": [
+					"NFTables",
+					"nft"
+				],
+				"extensions": [
+					"nft"
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "nft",
+				"scopeName": "source.nft",
+				"path": "./syntaxes/nft.json"
+			}
+		]
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"lint": "eslint . --ext .ts,.tsx",
+		"watch": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install && tsc"
+	},
+	"devDependencies": {
+		"@types/node": "^12.12.0",
+		"@types/vscode": "^1.38.0",
+		"@typescript-eslint/eslint-plugin": "^4.16.0",
+		"@typescript-eslint/parser": "^4.16.0",
+		"eslint": "^7.21.0",
+		"typescript": "^4.2.2"
+	},
+	"__metadata": {
+		"id": "c5d628a9-92b9-48ed-9b1d-1cb60aea79bd",
+		"publisherId": "04f38382-fd0a-4fc7-8de4-f57dbc9520be",
+		"publisherDisplayName": null
+	},
+	"dependencies": {
+		"vscode": "^1.1.37"
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,48 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+
+    vscode.languages.registerDocumentFormattingEditProvider({ scheme: 'file', language: 'nft' }, {
+        provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+
+            let edits:vscode.TextEdit[] = [];
+
+            let indentLevel: number = 0;
+
+            for (var i = 0; i < document.lineCount; i++) {
+                const line: string = document.lineAt(i).text.trim();
+
+                let skip: Boolean = false;
+
+                if (line.includes("{") && line.includes("}")) {
+                    skip = true;
+                }
+
+                if (!skip && line.endsWith("}")) {
+                    indentLevel--;
+                }
+
+                // Generate new indentated line
+                let newline:string = "\t".repeat(indentLevel) + line;
+
+                if (newline.trim() == "") {
+                    // No indentation for empty line
+                    newline = "";
+                }
+
+                edits.push(
+                    vscode.TextEdit.replace(document.lineAt(i).range, newline)
+                );
+
+                if (!skip && line.endsWith("{")) {
+                    indentLevel++;
+                }
+
+            }
+
+            return edits;
+        }
+    });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2019",
+        "lib": [
+            "ES2019"
+        ],
+        "outDir": "out",
+        "sourceMap": true,
+        "strict": true,
+        "rootDir": "./src"
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
Hello,

This adds indentation formatting support for `nftables` rules. It simply adds indentation level based on lines ending with braces (`{}`). Format document (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>).
