### PR TITLE
fix: coloring of maps, comments w/ key words, colons in strings

### DIFF
--- a/src/nft.json
+++ b/src/nft.json
@@ -744,6 +744,13 @@
 				}
 			]
 		},
+		"map_block": {
+			"patterns": [
+				{
+					"include": "#set_block"
+				}
+			]
+		},
 		"stmt": {
 			"patterns": [
 				{
@@ -1055,7 +1062,7 @@
 					"include": "#match_stmt"
 				},
 				{
-					"match": "([^;]*)\\s+(set)\\s+([^;]*)",
+					"match": "([^;#]*)\\s+(set)\\s+([^;]*)",
 					"name": "meta.stmt.payload.nft",
 					"captures": {
 						"1": {
@@ -1085,7 +1092,7 @@
 					"include": "#verdict_expr"
 				},
 				{
-					"begin": "([^;]*)\\s+(vmap)",
+					"begin": "([^;#]*)\\s+(vmap)",
 					"name": "meta.stmt.verdict",
 					"beginCaptures": {
 						"1": {
@@ -1984,7 +1991,7 @@
 					"include": "#set_expr"
 				},
 				{
-					"match": "([^,;:{]+)\\s*(:)\\s*([^,;:}]+)",
+					"match": "([^\",;:{]+)\\s*(:)\\s*([^\",;:}]+)",
 					"captures": {
 						"1": {
 							"patterns": [


### PR DESCRIPTION
Hi,

attached file [sets_and_maps.nft](https://github.com/omBratteng/vscode-nftables/files/6326516/sets_and_maps.nft.txt) is an example from the Debian _nftables_ package.

There appear to be some issues with syntax highlighting:

* line 30-36: maps not colored (correctly)
* line 38-40: chain name not colored
* line 46+52: comments with certain key words not colored correctly

![sets_and_maps](https://user-images.githubusercontent.com/46762314/115053972-fd547b80-9edf-11eb-8777-9758df9ca079.png)

This pull request should fix the above issues + the one from issue #25:

* line 30-36: definition of "map_block": is missing
* line 38-40: ignore, it's a subsequent error from above "map_block" issue
* line 46+52: set and vmap definitions overwrite comment coloring
* issue #25: set_list_member_expr applied in quoted string

Regards
Andreas
