### PR TITLE
fix: coloring priority when default names (nat, filter, mangle..) are used instead of numeric values

### DIFF
--- a/src/nft.json
+++ b/src/nft.json
@@ -582,7 +582,7 @@
 			}
 		},
 		"hook_spec": {
-			"match": "(type)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s+(hook)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s+(?:(device)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s+)?(priority)\\s+(-?\\d+)",
+			"match": "(type)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s+(hook)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s+(?:(device)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s+)?(priority)\\s+(-?\\d+|[a-z]+)",
 			"captures": {
 				"1": {
 					"name": "keyword.function.type.nft"


### PR DESCRIPTION
Fix the colorization of priority when default names are used instead of a numeric value.

example: `type nat hook prerouting priority dstnat; policy accept;`