### PR TITLE
nft syntax: updated string.quoted.double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "nft" extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- chore(deps): bump dependencies
+- chore(deps): set dependabot to weekly interval
+- chore(deps): change the `@types/node` dependency range
+
 ## [0.4.4] - 2021-10-13
 
 - chore(deps): bump dependencies
@@ -90,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release [`bf39000`](https://github.com/omBratteng/vscode-nftables/commit/bf39000)
 
+[Unreleased]: https://github.com/omBratteng/vscode-nftables/compare/0.4.4...main
 [0.4.4]: https://github.com/omBratteng/vscode-nftables/compare/0.4.3...0.4.4
 [0.4.3]: https://github.com/omBratteng/vscode-nftables/compare/0.4.2...0.4.3
 [0.4.2]: https://github.com/omBratteng/vscode-nftables/compare/0.4.1...0.4.2

--- a/src/nft.json
+++ b/src/nft.json
@@ -1904,7 +1904,7 @@
           "name": "constant.numeric.hexadecimal.nft"
         },
         {
-          "match": "\\b\"[^\"]*\"\\b",
+          "match": "\\b\"*\"\\b",
           "name": "string.quoted.double"
         },
         {


### PR DESCRIPTION
Handle multiple double quoted strings in one line correctly.
syntax highlighting before
![sqd1](https://user-images.githubusercontent.com/46762314/151199475-c5f06a7e-b91e-4170-800b-f130a115349b.png)
and after the change
![sqd2](https://user-images.githubusercontent.com/46762314/151199509-4935e7f4-e64c-4626-9c6b-40c2b73e4976.png)
This should fix #130. 