### PR TITLE
redefine and undefine support + coloring fixes

### DIFF
--- a/src/nft.json
+++ b/src/nft.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "NFTables",
-  "fileTypes": [
-    "nft"
-  ],
+  "fileTypes": ["nft"],
   "firstLineMatch": "^#!.*nft",
   "foldingStartMarker": "\\{\\s*$",
   "foldingStopMarker": "^\\s*\\}",
@@ -1421,7 +1419,7 @@
           "name": "delimiter.prefix.nft"
         },
         "3": {
-          "name": "constant.prefixlen.numeric.nft"
+          "name": "constant.numeric.prefixlen.nft"
         }
       }
     },

--- a/src/nft.json
+++ b/src/nft.json
@@ -40,7 +40,7 @@
           }
         },
         {
-          "begin": "(define)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s*(=)",
+          "begin": "(define|redefine)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)\\s*(=)",
           "beginCaptures": {
             "1": {
               "name": "keyword.define.nft"
@@ -61,6 +61,17 @@
             }
           ],
           "end": "(?=;|$)"
+        },
+        {
+          "match": "(undefine)\\s+([a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)",
+          "captures": {
+            "1": {
+              "name": "keyword.undefine.nft"
+            },
+            "2": {
+              "name": "variable.other.define.nft"
+            }
+          }
         }
       ]
     },

--- a/src/nft.json
+++ b/src/nft.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "NFTables",
-  "fileTypes": ["nft"],
+  "fileTypes": [
+    "nft"
+  ],
   "firstLineMatch": "^#!.*nft",
   "foldingStartMarker": "\\{\\s*$",
   "foldingStopMarker": "^\\s*\\}",
@@ -674,8 +676,12 @@
             }
           ]
         },
-        "2": "support.function.handle.nft",
-        "3": "constant.numeric.rulehandle.nft"
+        "2": {
+          "name": "support.function.handle.nft"
+        },
+        "3": {
+          "name": "constant.numeric.rulehandle.nft"
+        }
       }
     },
     "rule_position": {


### PR DESCRIPTION
Hi and thanks for porting my grammar to vscode!

I had a few very small local changes that never made it to github in the original repository, which I thought I'd send for inclusion in here. 

* Support for redefine and undefine, introduced in nftables 1.0.2
* Fix for incorrect syntax in matching of `delete rule t c handle <number>`
* Change the class name to a known prefix for prefix lengths so that it gets recognized by themes as a constant and colored adequately